### PR TITLE
Tweak gradients in memberlist count

### DIFF
--- a/gradients.css
+++ b/gradients.css
@@ -66,7 +66,7 @@ I6,
   background-image: linear-gradient(var(--gradient-direction),var(--gradient-color1),var(--gradient-color2)) !important;
   background-color: var(--main-color);
 }
-.members-3WRCEx .membersGroup-2eiWxl,
+.members-3WRCEx .membersGroup-2eiWxl:not([style*="color: rgb"]) span,
 .sidebar-1tnWFu .containerDefault-3TQ5YN .wrapper-1S43wv .name-3BUDLf .overflow-1wOqNV,/*Thx Addy*/
 .headerText-1qIDDT, /* dm categories */
 .discoverHeader-1TWTqG, 


### PR DESCRIPTION
This should fix the memberlist names and numbers from vanishing when used in ClearVision