### PR TITLE
Improved video progress bars

### DIFF
--- a/gradients.css
+++ b/gradients.css
@@ -103,3 +103,13 @@
 .textBadge_df8943 {
   box-shadow: none !important;
 }
+
+.mediaBarWrapper_d12f5a,
+.mediaBarProgress_d12f5a {
+    border-radius: 3px;
+}
+
+.fakeEdges_d12f5a:before,
+.fakeEdges_d12f5a:after {
+    content: unset;
+}

--- a/textAreaUnderline.css
+++ b/textAreaUnderline.css
@@ -58,8 +58,3 @@ If you are not using another theme, uncomment root.
   border-bottom-left-radius: 2px;
   border-bottom-right-radius: 2px;
 }
-
-.channelAppLauncher_df39bd button {
-  height: 50px;
-  width: 50px;
-}

--- a/textAreaUnderline.css
+++ b/textAreaUnderline.css
@@ -58,3 +58,8 @@ If you are not using another theme, uncomment root.
   border-bottom-left-radius: 2px;
   border-bottom-right-radius: 2px;
 }
+
+.channelAppLauncher_df39bd button {
+  height: 50px;
+  width: 50px;
+}


### PR DESCRIPTION
## Before
![Before](https://github.com/user-attachments/assets/e3482754-06a2-4e24-a29b-199083b06771)

## After
![After](https://github.com/user-attachments/assets/9153695d-9992-4041-900a-0c388f24d946)

## Info
The progress bar does get a little shorter, but it shouldn't cause issues for usability in terms of scrubbing through the video. The fix is the removal of those weird nubs at the start and end of the progress bar, if that wasn't clear.